### PR TITLE
Fix no contributors reported

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -129,7 +129,7 @@ const getContributors = async () => {
     .filter(
       ({ email }) =>
         isString(pkgAuthor)
-          ? new RegExp(pkgAuthor, 'i').test(email)
+          ? !new RegExp(pkgAuthor, 'i').test(email)
           : !isSameEmail(pkgAuthor.email, email)
     )
     .sort((c1, c2) => c2.commits - c1.commits)


### PR DESCRIPTION
Fix wrong logic trying to skip author in contributors list. There was a typo that filtered out any contributors with an email matching the author name.