### PR TITLE
fix: create a new email validator every time

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
-const emailRegex = require('email-regex')()
+const emailRegex = require('email-regex')
 const existsFile = require('exists-file')
 const jsonFuture = require('json-future')
 const execa = require('execa')
@@ -133,7 +133,7 @@ const getContributors = async () => {
         ? !new RegExp(pkgAuthor, 'i').test(email)
         : !isSameEmail(pkgAuthor.email, email)
     )
-    .filter(({ email }) => emailRegex.test(email))
+    .filter(({ email }) => emailRegex().test(email))
     .sort((c1, c2) => c2.commits - c1.commits)
 
   const maxIndent = contributors.length ? getMaxIndent(contributors, 'commits') : ''


### PR DESCRIPTION
I noticed half of the contributors to my project had disappeared after the `v1.0.20` release.

You have to create a new `email-regex` with [every use](https://runkit.com/embed/lf3yjvbh3wgz), otherwise it breaks:

```javascript
const emailRegex = require("email-regex")
const reg = emailRegex()

console.info(reg.test('foo@bar.com')) // true
console.info(reg.test('foo@bar.com')) // false
console.info(reg.test('foo@bar.com')) // true
console.info(reg.test('foo@bar.com')) // false
```