### PR TITLE
fix(sorting): sort authors by email and name before sorting by commit count

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -143,8 +143,8 @@ const getContributors = async () => {
     .sort(
       (c1, c2) =>
         c1.commits - c2.commits || // sort by commit count
-        c1.name.toLowerCase().localeCompare(c2.name.toLowerCase()) || // if equal, sort by name
-        c1.email.localeCompare(c2.email) // if equal, sort by email
+        c1.email.localeCompare(c2.email) || // if equal, sort by email
+        c1.name.toLowerCase().localeCompare(c2.name.toLowerCase()) // if equal, sort by name
     )
 
   const maxIndent = contributors.length ? getMaxIndent(contributors, 'commits') : ''

--- a/bin/index.js
+++ b/bin/index.js
@@ -140,7 +140,12 @@ const getContributors = async () => {
     )
     .filter(({ email }) => emailRegex().test(email))
     .filter(({ author }) => !(ignorePatternReg && ignorePatternReg.test(author)))
-    .sort((c1, c2) => c2.commits - c1.commits)
+    .sort(
+      (c1, c2) =>
+        c1.commits - c2.commits || // sort by commit count
+        c1.name.toLowerCase().localeCompare(c2.name.toLowerCase()) || // if equal, sort by name
+        c1.email.localeCompare(c2.email) // if equal, sort by email
+    )
 
   const maxIndent = contributors.length ? getMaxIndent(contributors, 'commits') : ''
 


### PR DESCRIPTION
The output of the cli isn’t deterministic:
Authors with the same commit count may appear in a random(?) order.
To avoid the churn of shuffling lines, we can sort the authors by email and name first.