### PR TITLE
feat: add column headers to CLI output

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -52,24 +52,31 @@ const indent = (maxIndentation, prop = '') => {
 }
 
 const renderContributorsVerbose = (contributors, maxIndent) => {
-  const maxIndexIndent = String(contributors.length).length
+  // The minimum width of the first column is the length of the string 'Commits'
+  const firstColumnMinWidth = 5
 
   console.log()
+  console.log('Index  Commits  Author')
   contributors.forEach(({ author, commits, name }, index) => {
     const prettyAuthor = colors.gray(author.replace(name, colors.white(name)))
     const prettyCommits = colors.white(`${indent(maxIndent, commits)}${commits}`)
     const humanIndex = index + 1
-    const prettyIndex = colors.gray(`${indent(maxIndexIndent, humanIndex)}${humanIndex}`)
-    console.log(`  ${prettyIndex} ${prettyCommits} ${prettyAuthor}`)
+    // Indent index the width of the string 'Index'
+    const prettyIndex = colors.gray(`${indent(firstColumnMinWidth, humanIndex)}${humanIndex}`)
+    console.log(`${prettyIndex}     ${prettyCommits}   ${prettyAuthor}`)
   })
 }
 
 const renderContributors = (contributors, maxIndent) => {
+  // The minimum width of the first column is the length of the string 'Commits'
+  const firstColumnMinWidth = 7
+
   console.log()
+  console.log('Commits  Author')
   contributors.forEach(({ author, commits, name }) => {
     const prettyAuthor = colors.gray(author.replace(name, colors.white(name)))
-    const prettyCommits = colors.white(`${indent(maxIndent, commits)}${commits}`)
-    console.log(`  ${prettyCommits}  ${prettyAuthor}`)
+    const prettyCommits = colors.white(`${indent(firstColumnMinWidth, commits)}${commits}`)
+    console.log(`${prettyCommits}  ${prettyAuthor}`)
   })
 }
 


### PR DESCRIPTION
This PR adds column headers to the standard and verbose outputs, for ease of readability. There's no indication currently, apart from the semi-obvious assumption, that the "ranking" is based on number of commits.

Standard output
![CleanShot 2024-10-17 at 10 46 02](https://github.com/user-attachments/assets/ce9299d4-b056-47f4-97c1-e504c5898b42)

Verbose output
![CleanShot 2024-10-17 at 10 46 30](https://github.com/user-attachments/assets/de98d629-d17b-49ef-a4f6-c7074367993d)
